### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,5 +1,7 @@
 # https://github.com/microsoft/windows-rs/blob/master/.github/workflows/
 name: rust-action for Windows
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/casaub0n/casaub0n/security/code-scanning/3](https://github.com/casaub0n/casaub0n/security/code-scanning/3)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow only checks Rust code and does not require write access, we will set `contents: read` as the minimal permission. This ensures the workflow has only the permissions it needs to function correctly.

The `permissions` block will be added at the root level of the workflow, applying to all jobs. This is the most efficient approach since all jobs in the workflow share the same minimal permission requirements.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
