### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pnpm.yml
+++ b/.github/workflows/pnpm.yml
@@ -10,6 +10,8 @@ on:
 
 jobs:
   dotfiles:
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/casaub0n/casaub0n/security/code-scanning/1](https://github.com/casaub0n/casaub0n/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the `dotfiles` job. Since the job appears to only run local scripts and does not seem to require write access to the repository, we will set the permissions to `contents: read`, which is the minimal permission required for most workflows. This change will ensure that the job adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
