### PR TITLE
fix eslint for next.js

### DIFF
--- a/apps/casaub0n-page/eslint.config.mjs
+++ b/apps/casaub0n-page/eslint.config.mjs
@@ -2,8 +2,12 @@ import { defineConfig } from "eslint/config";
 import base from "@casaub0n/eslint-config-next";
 
 export default defineConfig([
+  // VSCode ESLint extension can't find `tsconfigRootDir`
+  {
+    ignores: ["**/eslint.config.mjs"],
+  },
   ...base({
-    tsconfigRootDir: import.meta.dirname,
+    tsConfigurationRootDirectory: import.meta.dirname,
     tsconfigFileName: "./tsconfig.json",
     rootDirectory: import.meta.dirname,
   }),

--- a/apps/catalog/eslint.config.mjs
+++ b/apps/catalog/eslint.config.mjs
@@ -3,7 +3,10 @@ import storybook from "eslint-plugin-storybook";
 
 import base from "../../packages/eslint-config/eslint-base/dist/index.mjs";
 
-export default [...base({
-  tsconfigRootDir: import.meta.dirname,
-  tsconfigFileName: "./tsconfig.json",
-}), ...storybook.configs["flat/recommended"]];
+export default [
+  ...base({
+    tsConfigurationRootDirectory: import.meta.dirname,
+    tsconfigFileName: "./tsconfig.json",
+  }),
+  ...storybook.configs["flat/recommended"],
+];

--- a/apps/next-casaub0n/eslint.config.mjs
+++ b/apps/next-casaub0n/eslint.config.mjs
@@ -3,7 +3,7 @@ import base from "@casaub0n/eslint-config-next";
 
 export default defineConfig([
   ...base({
-    tsconfigRootDir: import.meta.dirname,
+    tsConfigurationRootDirectory: import.meta.dirname,
     tsconfigFileName: import.meta.dirname + "/tsconfig.json",
     rootDirectory: import.meta.dirname,
   }),

--- a/apps/shadcn-story/eslint.config.mjs
+++ b/apps/shadcn-story/eslint.config.mjs
@@ -3,7 +3,7 @@ import base from "@casaub0n/eslint-base";
 
 export default defineConfig([
   ...base({
-    tsconfigRootDir: import.meta.dirname,
+    tsConfigurationRootDirectory: import.meta.dirname,
     tsconfigFileName: "./tsconfig.json",
   }),
 ]);

--- a/packages/eslint-config/astro/README.md
+++ b/packages/eslint-config/astro/README.md
@@ -11,7 +11,7 @@ This is flat config. Check [peerDependencies](./package.json).
 
 This is a example eslint config.
 
-Use `tsconfigRootDir` and `tsconfigFileName` to point tsconfig.json location.
+Use `tsConfigurationRootDirectory` and `tsconfigFileName` to point tsconfig.json location.
 
 ```js
 import { defineConfig } from "eslint/config";
@@ -19,7 +19,7 @@ import base from "@casaub0n/eslint-base";
 
 export default defineConfig([
   ...base({
-    tsconfigRootDir: import.meta.dirname,
+    tsConfigurationRootDirectory: import.meta.dirname,
     tsconfigFileName: "./tsconfig.json",
   }),
 ]);

--- a/packages/eslint-config/astro/eslint.config.mjs
+++ b/packages/eslint-config/astro/eslint.config.mjs
@@ -2,8 +2,12 @@ import { defineConfig } from "eslint/config";
 import base from "@casaub0n/eslint-base";
 
 export default defineConfig([
+  // VSCode ESLint extension can't find `tsconfigRootDir`
+  {
+    ignores: ["**/eslint.config.mjs", "**/dist/**"],
+  },
   ...base({
-    tsconfigRootDir: import.meta.dirname,
+    tsConfigurationRootDirectory: import.meta.dirname,
     tsconfigFileName: "./tsconfig.json",
   }),
 ]);

--- a/packages/eslint-config/astro/package.json
+++ b/packages/eslint-config/astro/package.json
@@ -34,7 +34,7 @@
     "build": "tsdown",
     "build:watch": "tsdown --watch src",
     "type:check": "tsc --noEmit",
-    "lint": "pnpm dlx eslint src/**"
+    "lint": "eslint src/**"
   },
   "peerDependencies": {
     "@cspell/eslint-plugin": "catalog:",

--- a/packages/eslint-config/eslint-base/README.md
+++ b/packages/eslint-config/eslint-base/README.md
@@ -11,7 +11,7 @@ This is flat config. Check [peerDependencies](./package.json).
 
 This is a example eslint config.
 
-Use `tsconfigRootDir` and `tsconfigFileName` to point tsconfig.json location.
+Use `tsConfigurationRootDirectory` and `tsconfigFileName` to point tsconfig.json location.
 
 ```js
 import { defineConfig } from "eslint/config";
@@ -19,7 +19,7 @@ import base from "@casaub0n/eslint-base";
 
 export default defineConfig([
   ...base({
-    tsconfigRootDir: import.meta.dirname,
+    tsConfigurationRootDirectory: import.meta.dirname,
     tsconfigFileName: "./tsconfig.json",
   }),
 ]);

--- a/packages/eslint-config/eslint-base/eslint.config.mjs
+++ b/packages/eslint-config/eslint-base/eslint.config.mjs
@@ -2,8 +2,12 @@ import { defineConfig } from "eslint/config";
 import base from "./dist/index.mjs";
 
 export default defineConfig([
+  // VSCode ESLint extension can't find `tsconfigRootDir`
+  {
+    ignores: ["**/eslint.config.mjs", "**/dist/**"],
+  },
   ...base({
-    tsconfigRootDir: import.meta.dirname,
+    tsConfigurationRootDirectory: import.meta.dirname,
     tsconfigFileName: "./tsconfig.json",
   }),
 ]);

--- a/packages/eslint-config/eslint-base/src/index.ts
+++ b/packages/eslint-config/eslint-base/src/index.ts
@@ -22,14 +22,14 @@ import eslintPluginYml from "eslint-plugin-yml";
  *
  * So, the user will call a compiled ESM file into their `eslint.config.mjs`.
  * @param tsconfigFileName `./tsconfig.json`
- * @param tsconfigRootDir `import.meta.dirname` [The directory name of the current module. This is the same as the `path.dirname()` of the `import.meta.filename`.](https://nodejs.org/api/esm.html#importmetadirname)
+ * @param tsConfigurationRootDirectory `import.meta.dirname` [The directory name of the current module. This is the same as the `path.dirname()` of the `import.meta.filename`.](https://nodejs.org/api/esm.html#importmetadirname)
  * @example ```javascript
  * import { defineConfig } from "eslint/config";
  * import base from "@casaub0n/eslint-base";
  *
  * export default defineConfig([
  *   ...base({
- *     tsconfigRootDir: import.meta.dirname,
+ *     tsConfigurationRootDirectory: import.meta.dirname,
  *     tsconfigFileName: "./tsconfig.json",
  *   }),
  * ]);
@@ -37,11 +37,10 @@ import eslintPluginYml from "eslint-plugin-yml";
  */
 const config = ({
   tsconfigFileName = "./tsconfig.json",
-  // eslint-disable-next-line unicorn/prevent-abbreviations
-  tsconfigRootDir = import.meta.dirname,
+  tsConfigurationRootDirectory = import.meta.dirname,
 }: Readonly<{
   tsconfigFileName: string;
-  tsconfigRootDir: string;
+  tsConfigurationRootDirectory: string;
 }>): TSESLint.TSESLint.FlatConfig.ConfigArray =>
   tseslint.config([
     /**
@@ -66,7 +65,7 @@ const config = ({
         },
         parserOptions: {
           project: tsconfigFileName,
-          tsconfigRootDir,
+          tsconfigRootDir: tsConfigurationRootDirectory,
           sourceType: "module",
           projectService: true,
           ecmaVersion: "latest",

--- a/packages/eslint-config/next/README.md
+++ b/packages/eslint-config/next/README.md
@@ -11,7 +11,7 @@ This eslint config is for Next.js, and the config is flat config. Check [peerDep
 
 This is a example eslint config.
 
-Use `tsconfigRootDir` and `tsconfigFileName` to point tsconfig.json location. `rootDirectory` points current working directory.
+Use `tsConfigurationRootDirectory` and `tsconfigFileName` to point tsconfig.json location. `rootDirectory` points current working directory.
 
 ```js
 import { defineConfig } from "eslint/config";
@@ -19,7 +19,7 @@ import base from "@casaub0n/eslint-base";
 
 export default defineConfig([
   ...base({
-    tsconfigRootDir: import.meta.dirname,
+    tsConfigurationRootDirectory: import.meta.dirname,
     tsconfigFileName: "./tsconfig.json",
     rootDirectory: import.meta.dirname,
   }),

--- a/packages/eslint-config/next/eslint.config.mjs
+++ b/packages/eslint-config/next/eslint.config.mjs
@@ -2,8 +2,12 @@ import { defineConfig } from "eslint/config";
 import base from "@casaub0n/eslint-base";
 
 export default defineConfig([
+  // VSCode ESLint extension can't find `tsconfigRootDir`
+  {
+    ignores: ["**/eslint.config.mjs", "**/dist/**"],
+  },
   ...base({
-    tsconfigRootDir: import.meta.dirname,
+    tsConfigurationRootDirectory: import.meta.dirname,
     tsconfigFileName: "./tsconfig.json",
   }),
 ]);

--- a/packages/eslint-config/next/package.json
+++ b/packages/eslint-config/next/package.json
@@ -33,7 +33,7 @@
     "build": "tsdown",
     "build:watch": "tsdown --watch src",
     "type:check": "tsc --noEmit",
-    "lint": "pnpm dlx eslint src/**"
+    "lint": "eslint src/**"
   },
   "peerDependencies": {
     "@cspell/eslint-plugin": "catalog:",

--- a/packages/eslint-config/react/README.md
+++ b/packages/eslint-config/react/README.md
@@ -11,7 +11,7 @@ This eslint config is for Next.js, and the config is flat config. Check [peerDep
 
 This is a example eslint config.
 
-Use `tsconfigRootDir` and `tsconfigFileName` to point tsconfig.json location. `rootDirectory` points current working directory.
+Use `tsConfigurationRootDirectory` and `tsconfigFileName` to point tsconfig.json location. `rootDirectory` points current working directory.
 
 ```js
 import { defineConfig } from "eslint/config";
@@ -19,7 +19,7 @@ import base from "@casaub0n/eslint-base";
 
 export default defineConfig([
   ...base({
-    tsconfigRootDir: import.meta.dirname,
+    tsConfigurationRootDirectory: import.meta.dirname,
     tsconfigFileName: "./tsconfig.json",
     rootDirectory: import.meta.dirname,
   }),

--- a/packages/eslint-config/react/eslint.config.mjs
+++ b/packages/eslint-config/react/eslint.config.mjs
@@ -3,7 +3,7 @@ import base from "@casaub0n/eslint-base";
 
 export default defineConfig([
   ...base({
-    tsconfigRootDir: import.meta.dirname,
+    tsConfigurationRootDirectory: import.meta.dirname,
     tsconfigFileName: "./tsconfig.json",
   }),
 ]);

--- a/packages/eslint-config/react/package.json
+++ b/packages/eslint-config/react/package.json
@@ -33,7 +33,7 @@
     "build": "tsdown",
     "build:watch": "tsdown --watch src",
     "type:check": "tsc --noEmit",
-    "lint": "pnpm dlx eslint src/**"
+    "lint": "eslint src/**"
   },
   "peerDependencies": {
     "@cspell/eslint-plugin": "catalog:",

--- a/packages/eslint-config/react/src/index.ts
+++ b/packages/eslint-config/react/src/index.ts
@@ -36,7 +36,8 @@ const config = tseslint.config([
   },
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  pluginReact.configs.flat.recommended as any,
+  ...(pluginReact.configs.flat.recommended as any),
+  pluginReact.configs.flat["jsx-runtime"],
   {
     languageOptions: {
       // @ts-expect-error https://github.com/jsx-eslint/eslint-plugin-react/issues/3878

--- a/packages/eslint-config/utils/eslint.config.mjs
+++ b/packages/eslint-config/utils/eslint.config.mjs
@@ -3,7 +3,7 @@ import base from "@casaub0n/eslint-base";
 
 export default defineConfig([
   ...base({
-    tsconfigRootDir: import.meta.dirname,
+    tsConfigurationRootDirectory: import.meta.dirname,
     tsconfigFileName: "./tsconfig.json",
   }),
 ]);

--- a/packages/eslint-config/utils/package.json
+++ b/packages/eslint-config/utils/package.json
@@ -38,7 +38,7 @@
     "build": "tsdown",
     "build:watch": "tsdown --watch src",
     "type:check": "tsc --noEmit",
-    "lint": "pnpm dlx eslint src/**"
+    "lint": "eslint src/**"
   },
   "devDependencies": {
     "@casaub0n/eslint-base": "workspace:*",

--- a/packages/header-inserter/eslint.config.mjs
+++ b/packages/header-inserter/eslint.config.mjs
@@ -3,7 +3,7 @@ import base from "@casaub0n/eslint-base";
 
 export default defineConfig([
   ...base({
-    tsconfigRootDir: import.meta.dirname,
+    tsConfigurationRootDirectory: import.meta.dirname,
     tsconfigFileName: "./tsconfig.json",
   }),
 ]);

--- a/packages/ideal-addon/eslint.config.mjs
+++ b/packages/ideal-addon/eslint.config.mjs
@@ -2,7 +2,7 @@ import base from "@casaub0n/eslint-base";
 
 export default [
   ...base({
-    tsconfigRootDir: import.meta.dirname,
+    tsConfigurationRootDirectory: import.meta.dirname,
     tsconfigFileName: "./tsconfig.json",
   }),
   {

--- a/packages/lang-inserter/eslint.config.mjs
+++ b/packages/lang-inserter/eslint.config.mjs
@@ -2,7 +2,7 @@ import base from "@casaub0n/eslint-base";
 
 const baseEslint = [
   ...base({
-    tsconfigRootDir: import.meta.dirname,
+    tsConfigurationRootDirectory: import.meta.dirname,
     tsconfigFileName: "./tsconfig.json",
   }),
 ];

--- a/packages/maddon/eslint.config.mjs
+++ b/packages/maddon/eslint.config.mjs
@@ -3,7 +3,7 @@ import base from "@casaub0n/eslint-base";
 
 export default defineConfig([
   ...base({
-    tsconfigRootDir: import.meta.dirname,
+    tsConfigurationRootDirectory: import.meta.dirname,
     tsconfigFileName: "./tsconfig.json",
   }),
 ]);

--- a/packages/mklink/eslint.config.mjs
+++ b/packages/mklink/eslint.config.mjs
@@ -3,7 +3,7 @@ import base from "@casaub0n/eslint-base";
 
 export default defineConfig([
   ...base({
-    tsconfigRootDir: import.meta.dirname,
+    tsConfigurationRootDirectory: import.meta.dirname,
     tsconfigFileName: "./tsconfig.json",
   }),
 ]);

--- a/packages/parse-html/eslint.config.mjs
+++ b/packages/parse-html/eslint.config.mjs
@@ -3,7 +3,7 @@ import base from "@casaub0n/eslint-base";
 
 export default defineConfig([
   ...base({
-    tsconfigRootDir: import.meta.dirname,
+    tsConfigurationRootDirectory: import.meta.dirname,
     tsconfigFileName: "./tsconfig.json",
   }),
 ]);

--- a/packages/spidering/eslint.config.mjs
+++ b/packages/spidering/eslint.config.mjs
@@ -3,7 +3,7 @@ import base from "@casaub0n/eslint-base";
 
 export default defineConfig([
   ...base({
-    tsconfigRootDir: import.meta.dirname,
+    tsConfigurationRootDirectory: import.meta.dirname,
     tsconfigFileName: "./tsconfig.json",
   }),
   {

--- a/packages/test-driven-development-by-example/eslint.config.mjs
+++ b/packages/test-driven-development-by-example/eslint.config.mjs
@@ -3,7 +3,7 @@ import base from "@casaub0n/eslint-base";
 
 export default defineConfig([
   ...base({
-    tsconfigRootDir: import.meta.dirname,
+    tsConfigurationRootDirectory: import.meta.dirname,
     tsconfigFileName: "./tsconfig.json",
   }),
   {

--- a/packages/tsbox/eslint.config.mjs
+++ b/packages/tsbox/eslint.config.mjs
@@ -3,7 +3,7 @@ import base from "@casaub0n/eslint-base";
 
 export default defineConfig([
   ...base({
-    tsconfigRootDir: import.meta.dirname,
+    tsConfigurationRootDirectory: import.meta.dirname,
     tsconfigFileName: "./tsconfig.json",
   }),
 ]);


### PR DESCRIPTION
use utils type for next.js plugin and ignore eslint config file in each
projects
