### PR TITLE
fix eslint config for eslint.config.mjs

### DIFF
--- a/packages/eslint-config/astro/eslint.config.mjs
+++ b/packages/eslint-config/astro/eslint.config.mjs
@@ -4,7 +4,7 @@ import base from "@casaub0n/eslint-base";
 export default defineConfig([
   // VSCode ESLint extension can't find `tsconfigRootDir`
   {
-    ignores: ["**/eslint.config.mjs", "**/dist/**"],
+    ignores: ["**/*.mjs"],
   },
   ...base({
     tsConfigurationRootDirectory: import.meta.dirname,

--- a/packages/eslint-config/eslint-base/eslint.config.mjs
+++ b/packages/eslint-config/eslint-base/eslint.config.mjs
@@ -4,7 +4,7 @@ import base from "./dist/index.mjs";
 export default defineConfig([
   // VSCode ESLint extension can't find `tsconfigRootDir`
   {
-    ignores: ["**/eslint.config.mjs", "**/dist/**"],
+    ignores: ["**/*.mjs"],
   },
   ...base({
     tsConfigurationRootDirectory: import.meta.dirname,

--- a/packages/eslint-config/next/eslint.config.mjs
+++ b/packages/eslint-config/next/eslint.config.mjs
@@ -4,7 +4,7 @@ import base from "@casaub0n/eslint-base";
 export default defineConfig([
   // VSCode ESLint extension can't find `tsconfigRootDir`
   {
-    ignores: ["**/eslint.config.mjs", "**/dist/**"],
+    ignores: ["**/*.mjs"],
   },
   ...base({
     tsConfigurationRootDirectory: import.meta.dirname,

--- a/packages/eslint-config/react/eslint.config.mjs
+++ b/packages/eslint-config/react/eslint.config.mjs
@@ -2,6 +2,9 @@ import { defineConfig } from "eslint/config";
 import base from "@casaub0n/eslint-base";
 
 export default defineConfig([
+  {
+    ignores: ["**/*.mjs"],
+  },
   ...base({
     tsConfigurationRootDirectory: import.meta.dirname,
     tsconfigFileName: "./tsconfig.json",

--- a/packages/eslint-config/utils/eslint.config.mjs
+++ b/packages/eslint-config/utils/eslint.config.mjs
@@ -2,6 +2,9 @@ import { defineConfig } from "eslint/config";
 import base from "@casaub0n/eslint-base";
 
 export default defineConfig([
+  {
+    ignores: ["**/*.mjs"],
+  },
   ...base({
     tsConfigurationRootDirectory: import.meta.dirname,
     tsconfigFileName: "./tsconfig.json",

--- a/packages/header-inserter/eslint.config.mjs
+++ b/packages/header-inserter/eslint.config.mjs
@@ -2,6 +2,9 @@ import { defineConfig } from "eslint/config";
 import base from "@casaub0n/eslint-base";
 
 export default defineConfig([
+  {
+    ignores: ["**/*.mjs"],
+  },
   ...base({
     tsConfigurationRootDirectory: import.meta.dirname,
     tsconfigFileName: "./tsconfig.json",

--- a/packages/ideal-addon/eslint.config.mjs
+++ b/packages/ideal-addon/eslint.config.mjs
@@ -1,6 +1,10 @@
 import base from "@casaub0n/eslint-base";
+import { defineConfig } from "eslint/config";
 
-export default [
+export default defineConfig([
+  {
+    ignores: ["**/*.mjs"],
+  },
   ...base({
     tsConfigurationRootDirectory: import.meta.dirname,
     tsconfigFileName: "./tsconfig.json",
@@ -12,4 +16,4 @@ export default [
       "no-console": "off",
     },
   },
-];
+]);

--- a/packages/lang-inserter/eslint.config.mjs
+++ b/packages/lang-inserter/eslint.config.mjs
@@ -1,10 +1,12 @@
+import { defineConfig } from "eslint/config";
 import base from "@casaub0n/eslint-base";
 
-const baseEslint = [
+export default defineConfig([
+  {
+    ignores: ["**/*.mjs"],
+  },
   ...base({
     tsConfigurationRootDirectory: import.meta.dirname,
     tsconfigFileName: "./tsconfig.json",
   }),
-];
-
-export default baseEslint;
+]);

--- a/packages/maddon/eslint.config.mjs
+++ b/packages/maddon/eslint.config.mjs
@@ -2,6 +2,9 @@ import { defineConfig } from "eslint/config";
 import base from "@casaub0n/eslint-base";
 
 export default defineConfig([
+  {
+    ignores: ["**/*.mjs"],
+  },
   ...base({
     tsConfigurationRootDirectory: import.meta.dirname,
     tsconfigFileName: "./tsconfig.json",

--- a/packages/mklink/eslint.config.mjs
+++ b/packages/mklink/eslint.config.mjs
@@ -2,6 +2,9 @@ import { defineConfig } from "eslint/config";
 import base from "@casaub0n/eslint-base";
 
 export default defineConfig([
+  {
+    ignores: ["**/*.mjs"],
+  },
   ...base({
     tsConfigurationRootDirectory: import.meta.dirname,
     tsconfigFileName: "./tsconfig.json",

--- a/packages/parse-html/eslint.config.mjs
+++ b/packages/parse-html/eslint.config.mjs
@@ -2,6 +2,9 @@ import { defineConfig } from "eslint/config";
 import base from "@casaub0n/eslint-base";
 
 export default defineConfig([
+  {
+    ignores: ["**/*.mjs"],
+  },
   ...base({
     tsConfigurationRootDirectory: import.meta.dirname,
     tsconfigFileName: "./tsconfig.json",

--- a/packages/spidering/eslint.config.mjs
+++ b/packages/spidering/eslint.config.mjs
@@ -2,6 +2,9 @@ import { defineConfig } from "eslint/config";
 import base from "@casaub0n/eslint-base";
 
 export default defineConfig([
+  {
+    ignores: ["**/*.mjs"],
+  },
   ...base({
     tsConfigurationRootDirectory: import.meta.dirname,
     tsconfigFileName: "./tsconfig.json",

--- a/packages/test-driven-development-by-example/eslint.config.mjs
+++ b/packages/test-driven-development-by-example/eslint.config.mjs
@@ -2,6 +2,9 @@ import { defineConfig } from "eslint/config";
 import base from "@casaub0n/eslint-base";
 
 export default defineConfig([
+  {
+    ignores: ["**/*.mjs"],
+  },
   ...base({
     tsConfigurationRootDirectory: import.meta.dirname,
     tsconfigFileName: "./tsconfig.json",

--- a/packages/tsbox/eslint.config.mjs
+++ b/packages/tsbox/eslint.config.mjs
@@ -2,6 +2,9 @@ import { defineConfig } from "eslint/config";
 import base from "@casaub0n/eslint-base";
 
 export default defineConfig([
+  {
+    ignores: ["**/*.mjs"],
+  },
   ...base({
     tsConfigurationRootDirectory: import.meta.dirname,
     tsconfigFileName: "./tsconfig.json",


### PR DESCRIPTION
current my config uses only `@typescript-eslint/parser`,
eslint.config.mjs sets on a project's root. Tsconfig is not include this
file.
